### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -28,11 +28,9 @@ namespace UnsecureApp.Controllers
         {
             using (SqlConnection connection = new SqlConnection(connectionString))
             {
-                SqlCommand sqlCommand = new SqlCommand()
-                {
-                    CommandText = "SELECT ProductId FROM Products WHERE ProductName = '" + productName + "'",
-                    CommandType = CommandType.Text,
-                };
+                SqlCommand sqlCommand = new SqlCommand("SELECT ProductId FROM Products WHERE ProductName = @productName", connection);
+                sqlCommand.CommandType = CommandType.Text;
+                sqlCommand.Parameters.Add(new SqlParameter("@productName", productName));
 
                 SqlDataReader reader = sqlCommand.ExecuteReader();
                 return reader.GetInt32(0); 


### PR DESCRIPTION
Potential fix for [https://github.com/geovanams/Demo4GHAS/security/code-scanning/2](https://github.com/geovanams/Demo4GHAS/security/code-scanning/2)

To fix the problem, we should use parameterized queries instead of string concatenation to construct the SQL query. This approach ensures that user input is treated as a parameter and not as part of the SQL command, thus preventing SQL injection attacks.

- Replace the string concatenation in the SQL query with a parameterized query.
- Use the `SqlCommand.Parameters.Add` method to add the `productName` parameter to the query.
- Ensure that the `SqlCommand` object is properly associated with the `SqlConnection` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
